### PR TITLE
Remove DefinesEditorSettings.Save method

### DIFF
--- a/Assets/Scenes/Empty.unity
+++ b/Assets/Scenes/Empty.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_LightingSettings: {fileID: 0}
+  m_LightingSettings: {fileID: 4941834}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -123,3 +123,64 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!850595691 &4941834
+LightingSettings:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 3
+  m_GIWorkflowMode: 1
+  m_EnableBakedLightmaps: 1
+  m_EnableRealtimeLightmaps: 0
+  m_RealtimeEnvironmentLighting: 1
+  m_BounceScale: 1
+  m_AlbedoBoost: 1
+  m_IndirectOutputScale: 1
+  m_UsingShadowmask: 1
+  m_BakeBackend: 1
+  m_LightmapMaxSize: 1024
+  m_BakeResolution: 40
+  m_Padding: 2
+  m_TextureCompression: 1
+  m_AO: 0
+  m_AOMaxDistance: 1
+  m_CompAOExponent: 1
+  m_CompAOExponentDirect: 0
+  m_ExtractAO: 0
+  m_MixedBakeMode: 2
+  m_LightmapsBakeMode: 1
+  m_FilterMode: 1
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
+  m_ExportTrainingData: 0
+  m_TrainingDataDestination: TrainingData
+  m_RealtimeResolution: 2
+  m_ForceWhiteAlbedo: 0
+  m_ForceUpdates: 0
+  m_FinalGather: 0
+  m_FinalGatherRayCount: 256
+  m_FinalGatherFiltering: 1
+  m_PVRCulling: 1
+  m_PVRSampling: 1
+  m_PVRDirectSampleCount: 32
+  m_PVRSampleCount: 512
+  m_PVREnvironmentSampleCount: 256
+  m_PVREnvironmentReferencePointCount: 2048
+  m_LightProbeSampleCountMultiplier: 4
+  m_PVRBounces: 2
+  m_PVRMinBounces: 1
+  m_PVREnvironmentMIS: 1
+  m_PVRFilteringMode: 1
+  m_PVRDenoiserTypeDirect: 1
+  m_PVRDenoiserTypeIndirect: 1
+  m_PVRDenoiserTypeAO: 1
+  m_PVRFilterTypeDirect: 0
+  m_PVRFilterTypeIndirect: 0
+  m_PVRFilterTypeAO: 0
+  m_PVRFilteringGaussRadiusDirect: 1
+  m_PVRFilteringGaussRadiusIndirect: 5
+  m_PVRFilteringGaussRadiusAO: 2
+  m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+  m_PVRFilteringAtrousPositionSigmaIndirect: 2
+  m_PVRFilteringAtrousPositionSigmaAO: 1

--- a/Packages/UGF.Defines/Editor/DefinesBuildPreprocess.cs
+++ b/Packages/UGF.Defines/Editor/DefinesBuildPreprocess.cs
@@ -18,7 +18,7 @@ namespace UGF.Defines.Editor
                 DefinesBuildEditorUtility.SaveScriptingDefineSymbolsForGroup(group);
             }
 
-            if (DefinesEditorSettings.Settings.TryGetSettings(group, out DefinesSettings settings) && settings.IncludeInBuild)
+            if (DefinesEditorSettings.PlatformSettings.TryGetSettings(group, out DefinesSettings settings) && settings.IncludeInBuild)
             {
                 DefinesBuildEditorUtility.ApplyDefinesAll(group, settings);
             }

--- a/Packages/UGF.Defines/Editor/DefinesEditorSettings.cs
+++ b/Packages/UGF.Defines/Editor/DefinesEditorSettings.cs
@@ -8,31 +8,26 @@ namespace UGF.Defines.Editor
     {
         public static bool RestoreDefinesAfterBuild
         {
-            get { return m_settings.Data.RestoreDefinesAfterBuild; }
+            get { return Settings.Data.RestoreDefinesAfterBuild; }
             set
             {
-                m_settings.Data.RestoreDefinesAfterBuild = value;
-                m_settings.SaveSettings();
+                Settings.Data.RestoreDefinesAfterBuild = value;
+                Settings.SaveSettings();
             }
         }
 
-        public static PlatformSettings<DefinesSettings> Settings { get { return m_settings.Data.Settings; } }
+        public static PlatformSettings<DefinesSettings> PlatformSettings { get { return Settings.Data.Settings; } }
 
-        private static readonly CustomSettingsEditorPackage<DefinesEditorSettingsData> m_settings = new CustomSettingsEditorPackage<DefinesEditorSettingsData>
+        public static CustomSettingsEditorPackage<DefinesEditorSettingsData> Settings { get; } = new CustomSettingsEditorPackage<DefinesEditorSettingsData>
         (
             "UGF.Defines",
             "DefinesEditorSettings"
         );
 
-        public static void Save()
-        {
-            m_settings.SaveSettings();
-        }
-
         [SettingsProvider]
         private static SettingsProvider GetProvider()
         {
-            return new CustomSettingsProvider<DefinesEditorSettingsData>("Project/UGF/Defines", m_settings, SettingsScope.Project);
+            return new CustomSettingsProvider<DefinesEditorSettingsData>("Project/UGF/Defines", Settings, SettingsScope.Project);
         }
     }
 }

--- a/Packages/UGF.Defines/Editor/DefinesEditorSettingsData.cs
+++ b/Packages/UGF.Defines/Editor/DefinesEditorSettingsData.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace UGF.Defines.Editor
 {
-    internal class DefinesEditorSettingsData : CustomSettingsData
+    public class DefinesEditorSettingsData : CustomSettingsData
     {
         [SerializeField] private bool m_restoreDefinesAfterBuild = true;
         [SerializeField] private PlatformSettings<DefinesSettings> m_settings = new PlatformSettings<DefinesSettings>();

--- a/Packages/UGF.Defines/Editor/DefinesEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Defines/Editor/DefinesEditorSettingsDataEditor.cs
@@ -44,7 +44,7 @@ namespace UGF.Defines.Editor
 
         private void OnApplied(string groupName, BuildTargetGroup buildTargetGroup)
         {
-            if (DefinesEditorSettings.Settings.TryGetSettings(buildTargetGroup, out DefinesSettings settings))
+            if (DefinesEditorSettings.PlatformSettings.TryGetSettings(buildTargetGroup, out DefinesSettings settings))
             {
                 DefinesBuildEditorUtility.ApplyDefinesAll(buildTargetGroup, settings);
                 AssetDatabase.SaveAssets();
@@ -53,7 +53,7 @@ namespace UGF.Defines.Editor
 
         private void OnCleared(string groupName, BuildTargetGroup buildTargetGroup)
         {
-            if (DefinesEditorSettings.Settings.TryGetSettings(buildTargetGroup, out DefinesSettings settings))
+            if (DefinesEditorSettings.PlatformSettings.TryGetSettings(buildTargetGroup, out DefinesSettings settings))
             {
                 DefinesBuildEditorUtility.ClearDefinesAll(buildTargetGroup, settings);
                 AssetDatabase.SaveAssets();


### PR DESCRIPTION
- Remove `DefinesEditorSettings.Save` method, use `DefinesEditorSettings.Settings.SaveSettings` instead.
- Change `DefinesEditorSettingsData` class to be public.
- Change `DefinesEditorSettings.Settings` property name to `DefinesEditorSettings.PlatformSettings`.
- Change `CustomSettingsEditorPackage<DefinesEditorSettingsData>` instance to be public and accessible from `DefinesEditorSettings`.