### PR TITLE
Change build processors order value when Unity fix become available

### DIFF
--- a/Packages/UGF.Defines/Editor/DefinesBuildPostprocess.cs
+++ b/Packages/UGF.Defines/Editor/DefinesBuildPostprocess.cs
@@ -6,7 +6,7 @@ namespace UGF.Defines.Editor
 {
     internal class DefinesBuildPostprocess : IPostprocessBuildWithReport
     {
-        public int callbackOrder { get; } = 1000000;
+        public int callbackOrder { get; } = int.MaxValue;
 
         public void OnPostprocessBuild(BuildReport report)
         {

--- a/Packages/UGF.Defines/Editor/DefinesBuildPreprocess.cs
+++ b/Packages/UGF.Defines/Editor/DefinesBuildPreprocess.cs
@@ -7,7 +7,7 @@ namespace UGF.Defines.Editor
 {
     internal class DefinesBuildPreprocess : IPreprocessBuildWithReport
     {
-        public int callbackOrder { get; } = -1000000;
+        public int callbackOrder { get; } = int.MinValue;
 
         public void OnPreprocessBuild(BuildReport report)
         {

--- a/Packages/UGF.Defines/package.json
+++ b/Packages/UGF.Defines/package.json
@@ -3,6 +3,7 @@
   "displayName": "UGF.Defines",
   "version": "1.0.1",
   "unity": "2020.2",
+  "unityRelease": "2f1",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Utility to control custom compile defines in editor and during player build.",
   "author": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.3",
-    "com.unity.test-framework": "1.1.19"
+    "com.unity.test-framework": "1.1.22"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -25,7 +25,7 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -41,11 +41,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.19",
+      "version": "1.1.22",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.5",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0f1
-m_EditorVersionWithRevision: 2020.2.0f1 (3721df5a8b28)
+m_EditorVersion: 2020.2.2f1
+m_EditorVersionWithRevision: 2020.2.2f1 (068178b99f32)

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b12
-m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)
+m_EditorVersion: 2020.2.0f1
+m_EditorVersionWithRevision: 2020.2.0f1 (3721df5a8b28)


### PR DESCRIPTION
- Update `DefinesBuildPostprocess` and `DefinesBuildPreprocess` order values.
- Change required _Unity_ version to `2020.2.2f1`.