### PR TITLE
Change project settings root name

### DIFF
--- a/Packages/UGF.Defines/Editor/DefinesEditorSettings.cs
+++ b/Packages/UGF.Defines/Editor/DefinesEditorSettings.cs
@@ -27,7 +27,7 @@ namespace UGF.Defines.Editor
         [SettingsProvider]
         private static SettingsProvider GetProvider()
         {
-            return new CustomSettingsProvider<DefinesEditorSettingsData>("Project/UGF/Defines", Settings, SettingsScope.Project);
+            return new CustomSettingsProvider<DefinesEditorSettingsData>("Project/Unity Game Framework/Defines", Settings, SettingsScope.Project);
         }
     }
 }

--- a/Packages/UGF.Defines/package.json
+++ b/Packages/UGF.Defines/package.json
@@ -2,8 +2,7 @@
   "name": "com.ugf.defines",
   "displayName": "UGF.Defines",
   "version": "2.1.2",
-  "unity": "2020.2",
-  "unityRelease": "2f1",
+  "unity": "2020.3",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Utility to control custom compile defines in editor and during player build.",
   "author": {
@@ -17,10 +16,7 @@
   "changelogUrl": "https://github.com/unity-game-framework/ugf-defines/blob/master/changelog.md",
   "licensesUrl": "https://github.com/unity-game-framework/ugf-defines/blob/master/license",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/@unity-game-framework"
-  },
-  "bintray": {
-    "registry": "https://api.bintray.com/content/unity-game-framework/public"
+    "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
     "com.ugf.customsettings": "3.4.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.3",
-    "com.unity.test-framework": "1.1.22"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.24"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -33,16 +33,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.3",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.22",
+      "version": "1.1.24",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.2f1
-m_EditorVersionWithRevision: 2020.2.2f1 (068178b99f32)
+m_EditorVersion: 2020.3.9f1
+m_EditorVersionWithRevision: 2020.3.9f1 (108be757e447)


### PR DESCRIPTION
- Update project to Unity `2020.3`.
- Change project settings root name to `Unity Game Framework`.